### PR TITLE
[Major] make GetRaw working and add a cookie method

### DIFF
--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -74,6 +74,11 @@ func (c *Cookie) Get(name string) string{
 	return cookie.Value
 }
 
+// Returns the map of all the cookies
+func (c *Cookie) GetAll() map[string]*http.Cookie {
+	return c.cookies
+}
+
 // An internal function to set all the cookies before pushing response body
 func (c *Cookie) Finish(){
 	if c.readonly {

--- a/request/request.go
+++ b/request/request.go
@@ -49,6 +49,7 @@ func (req *Request) Init(request *http.Request, props *map[string]interface{}) *
 	req.Header = make(map[string]string)
 	req.Body = make(map[string][]string)
 	req.Body = request.Form
+	req.ref = request
 	req.Cookies = &cookie.Cookie{}
 	req.Cookies.InitReadOnly(request)
 	req.Query = make(map[string][]string)


### PR DESCRIPTION
- ```Request.GetRaw()``` seems to be broken from the beginning is now been fixed.
- Cookies package now has a new method ```GetAll()``` which returns a map of type ```map[string]*http.Cookie```
-  Will need a new release to be released.