### PR TITLE
Bug: append multiple headers

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -62,7 +62,7 @@ func (req *Request) Init(request *http.Request, props *map[string]interface{}) *
 	req.fileReader = nil
 	for key, value := range request.Header {
 		// lowercase the header key names
-		req.Header[strings.ToLower(key)] = value[0]
+		req.Header[strings.ToLower(key)] = strings.Join(value, ",")
 	}
 
 	if req.Header["Content-Type"] == "application/json" {


### PR DESCRIPTION
This PR fixes the multiple header value bug, currently only the first header value of a duplicate header name is respected rest are discarded, now header values will be concat with a separator ```val1,val2```.

__Note__: Currently goexpress will override headers with similar name but different alpha case i.e. a header ```X-Ref-Id``` and ```x-ref-Id``` will be treated as a same header, PR is welcome for the same.